### PR TITLE
Add the ability to select Query options when looking up workout samples

### DIFF
--- a/lib/health_kit_reporter.dart
+++ b/lib/health_kit_reporter.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 
+import 'model/SampleQueryOptions.dart';
 import 'model/payload/activity_summary.dart';
 import 'model/payload/category.dart';
 import 'model/payload/characteristic/characteristic.dart';
@@ -389,10 +390,15 @@ class HealthKitReporter {
 
   /// Returns [Workout] samples for the provided
   /// time interval predicate [predicate].
-  ///
-  static Future<List<Workout>> workoutQuery(Predicate predicate) async {
-    final result =
-        await _methodChannel.invokeMethod('workoutQuery', predicate.map);
+  /// [queryOption] parameter represents the options passable to the native HealthKit sample query
+  static Future<List<Workout>> workoutQuery(Predicate predicate,
+      {SampleQueryOption? queryOption}) async {
+    var arguments = <String, dynamic>{};
+    arguments.addAll(predicate.map);
+    if (queryOption != null) {
+      arguments["singleQueryOption"] = queryOption.value;
+    }
+    final result = await _methodChannel.invokeMethod('workoutQuery', arguments);
     final List<dynamic> list = jsonDecode(result);
     final workouts = <Workout>[];
     for (final Map<String, dynamic> map in list) {

--- a/lib/model/SampleQueryOptions.dart
+++ b/lib/model/SampleQueryOptions.dart
@@ -1,0 +1,19 @@
+import 'package:health_kit_reporter/health_kit_reporter.dart';
+
+/// The query options are used in HealthKit when querying samples
+/// The default query option is both [strictStartDate] and [strictEndDate]
+/// this allows you to choose either of the 3 other options
+enum SampleQueryOption { strictStartDate, strictEndDate, notStrict }
+
+extension Value on SampleQueryOption {
+  String get value {
+    switch (this) {
+      case SampleQueryOption.strictStartDate:
+        return "strictStartDate";
+      case SampleQueryOption.strictEndDate:
+        return "strictEndDate";
+      case SampleQueryOption.notStrict:
+        return "notStrict";
+    }
+  }
+}


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
This PR exposes the sample query options allowing us to use them in Flutter. This resolves issues that are outlined in #66 

There should be no regressions here as all this does is add an extra option to the `workoutQuery` in the Flutter plugin, the native extensions have been updated to accept this new argument and match the style that is applied to other methods. There is no native plugin change required. This is reverse compatible.
 

